### PR TITLE
Upgraded JSON support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ install: mvn install -P !build-extras -DskipTests=true -Dmaven.javadoc.skip=true
 script: mvn test -P !build-extras -B
 
 # Caches mvn repository in order to speed upbuilds
-cache:
-  directories:
-    - $HOME/.m2
+#cache:
+#  directories:
+#    - $HOME/.m2
 
 after_success:
   - ./cd/before-deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ install: mvn install -P !build-extras -DskipTests=true -Dmaven.javadoc.skip=true
 script: mvn test -P !build-extras -B
 
 # Caches mvn repository in order to speed upbuilds
-#cache:
-#  directories:
-#    - $HOME/.m2
+cache:
+  directories:
+    - $HOME/.m2
 
 after_success:
   - ./cd/before-deploy.sh

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.5,)</version>
+            <version>2.9.7</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hashmapinc.tempus</groupId>
     <artifactId>WitsmlObjects</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <name>WITSML Objects Helper Library</name>

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/WitsmlMarshal.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/WitsmlMarshal.java
@@ -3,9 +3,12 @@ package com.hashmapinc.tempus.WitsmlObjects.Util;
 import javax.xml.bind.*;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
@@ -60,5 +63,13 @@ public class WitsmlMarshal {
         ObjectMapper om = new ObjectMapper();
         om.setSerializationInclusion(Include.NON_NULL); // ignore null fields
         return om.writeValueAsString(witsmlObj);
+    }
+
+    public static <T> T deserializeFromJSON(
+        String json, 
+        Class witsmlClass
+    ) throws JsonParseException, JsonMappingException, IOException {
+        ObjectMapper om = new ObjectMapper();
+        return (T) om.readValue(json, witsmlClass);
     }
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/WitsmlMarshal.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/WitsmlMarshal.java
@@ -2,6 +2,7 @@ package com.hashmapinc.tempus.WitsmlObjects.Util;
 
 import javax.xml.bind.*;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -57,6 +58,7 @@ public class WitsmlMarshal {
      */
     public static <T> String serializeToJSON(T witsmlObj) throws JsonProcessingException{
         ObjectMapper om = new ObjectMapper();
+        om.setSerializationInclusion(Include.NON_NULL); // ignore null fields
         return om.writeValueAsString(witsmlObj);
     }
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/WitsmlMarshal.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/WitsmlMarshal.java
@@ -5,6 +5,7 @@ import javax.xml.bind.*;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -70,6 +71,7 @@ public class WitsmlMarshal {
         Class witsmlClass
     ) throws JsonParseException, JsonMappingException, IOException {
         ObjectMapper om = new ObjectMapper();
+        om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         return (T) om.readValue(json, witsmlClass);
     }
 }


### PR DESCRIPTION
This PR includes:
- `WitsmlMarshal` can now unmarshal from a json string
- `WitsmlMarshal` now ignores null fields when serializing a POJO to json string
