### PR TITLE
Df 232 1311 1411 conversion support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hashmapinc.tempus</groupId>
     <artifactId>WitsmlObjects</artifactId>
-    <version>1.1.17</version>
+    <version>1.1.18</version>
     <packaging>jar</packaging>
 
     <name>WITSML Objects Helper Library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hashmapinc.tempus</groupId>
     <artifactId>WitsmlObjects</artifactId>
-    <version>1.1.18</version>
+    <version>1.1.19</version>
     <packaging>jar</packaging>
 
     <name>WITSML Objects Helper Library</name>

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
@@ -18,7 +18,177 @@ public class LogConverter {
     // conversions to 1.4.1.1
     //=========================================================================
     public static com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog convertTo1411(com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog src) {
-        return null;
+        // get converted log
+        com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog dest = new com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog();
+
+        // check equality for non complex, non repeating fields
+        dest.setNameWell(src.getNameWell());
+        dest.setNameWellbore(src.getNameWellbore());
+        dest.setName(src.getName());
+        dest.setObjectGrowing(src.isObjectGrowing());
+        dest.setServiceCompany(src.getServiceCompany());
+        dest.setRunNumber(src.getRunNumber());
+        dest.setBhaRunNumber(src.getBhaRunNumber());
+        dest.setPass(src.getPass());
+        dest.setUidWell(src.getUidWell());
+        dest.setUidWellbore(src.getUidWellbore());
+        dest.setUid(src.getUid());
+        dest.setCreationDate(src.getCreationDate());
+        dest.setDescription(src.getDescription());
+        dest.setNullValue(src.getNullValue());
+        dest.setStartDateTimeIndex(src.getStartDateTimeIndex());
+        dest.setEndDateTimeIndex(src.getEndDateTimeIndex());
+
+        // check complex fields
+        // indexType
+        if (null != src.getIndexType())
+            assertEquals(src.getIndexType().value(), dest.getIndexType().value());
+
+        // startIndex
+        if (null != src.getStartIndex()) {
+            assertEquals(src.getStartIndex().getUom(), dest.getStartIndex().getUom());
+            assertEquals(src.getStartIndex().getValue(), dest.getStartIndex().getValue());
+        }
+
+        // endIndex
+        if (null != src.getEndIndex()) {
+            assertEquals(src.getEndIndex().getUom(), dest.getEndIndex().getUom());
+            assertEquals(src.getEndIndex().getValue(), dest.getEndIndex().getValue());
+        }
+
+        // stepIncrement
+        if (null != src.getStepIncrement()) {
+            assertEquals(src.getStepIncrement().getUom(), dest.getStepIncrement().getUom());
+            assertEquals(src.getStepIncrement().getValue(), dest.getStepIncrement().getValue());
+            assertEquals(src.getStepIncrement().getNumerator(), dest.getStepIncrement().getNumerator());
+            assertEquals(src.getStepIncrement().getDenominator(), dest.getStepIncrement().getDenominator());
+        }
+
+        // direction
+        if (null != src.getDirection())
+            assertEquals(src.getDirection().value(), dest.getDirection().value());
+
+        // indexCurve
+        if (null != src.getIndexCurve())
+            assertEquals(src.getIndexCurve().getValue(), dest.getIndexCurve());
+
+        // logData
+        if (null != src.getLogData())
+            assertEquals(src.getLogData().getData(), dest.getLogData().get(0).getData()); // TODO: confirm this conversion
+
+        // commonData
+        if (null != src.getCommonData()) {
+            assertEquals(src.getCommonData().getSourceName(), dest.getCommonData().getSourceName());
+            assertEquals(src.getCommonData().getDTimCreation(), dest.getCommonData().getDTimCreation());
+            assertEquals(src.getCommonData().getDTimLastChange(), dest.getCommonData().getDTimLastChange());
+            assertEquals(src.getCommonData().getItemState().value(), dest.getCommonData().getItemState().value());
+            assertEquals(src.getCommonData().getComments(), dest.getCommonData().getComments());
+        }
+
+        // customData
+        if (null != src.getCustomData() && null != src.getCustomData().getAny()){
+            for (int i = 0; i < src.getCustomData().getAny().size(); i++)
+                assertEquals(src.getCustomData().getAny().get(i), dest.getCustomData().getAny().get(i));
+        }
+
+        // check repeating fields
+        // logParam
+        if (null != src.getLogParam()) {
+            for (int i = 0; i < src.getLogParam().size(); i++) {
+                assertEquals(src.getLogParam().get(i).getDescription(), dest.getLogParam().get(i).getDescription());
+                assertEquals(src.getLogParam().get(i).getValue(), dest.getLogParam().get(i).getValue());
+                assertEquals(src.getLogParam().get(i).getIndex(), dest.getLogParam().get(i).getIndex());
+                assertEquals(src.getLogParam().get(i).getName(), dest.getLogParam().get(i).getName());
+                assertEquals(src.getLogParam().get(i).getUom(), dest.getLogParam().get(i).getUom());
+            }
+        }
+
+        // logParam
+        if (null != src.getLogCurveInfo()) {
+            for (int i = 0; i < src.getLogCurveInfo().size(); i++) {
+                com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo srcInfo = src.getLogCurveInfo().get(i);
+                com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo destInfo = dest.getLogCurveInfo().get(i);
+
+                // simple fields
+                assertEquals(srcInfo.getClassWitsml(), destInfo.getClassWitsml());
+                assertEquals(srcInfo.getUnit(), destInfo.getUnit());
+                assertEquals(srcInfo.getNullValue(), destInfo.getNullValue());
+                assertEquals(srcInfo.isAlternateIndex(), destInfo.isAlternateIndex());
+                assertEquals(srcInfo.getMinDateTimeIndex(), destInfo.getMinDateTimeIndex());
+                assertEquals(srcInfo.getMaxDateTimeIndex(), destInfo.getMaxDateTimeIndex());
+                assertEquals(srcInfo.getCurveDescription(), destInfo.getCurveDescription());
+                assertEquals(srcInfo.getDataSource(), destInfo.getDataSource());
+                assertEquals(srcInfo.getUid(), destInfo.getUid());
+
+                // complex fields
+                // mnemonic
+                if (null != srcInfo.getMnemonic())
+                    assertEquals(srcInfo.getMnemonic(), destInfo.getMnemonic().getValue());
+
+                // mnemAlias
+                if (null != srcInfo.getMnemAlias())
+                    assertEquals(srcInfo.getMnemAlias(), destInfo.getMnemAlias().getValue());
+                // wellDatum
+                if (null != srcInfo.getWellDatum()) {
+                    assertEquals(srcInfo.getWellDatum().getValue(), destInfo.getWellDatum().getValue());
+                    assertEquals(srcInfo.getWellDatum().getUidRef(), destInfo.getWellDatum().getUidRef());
+                }
+
+                // minIndex
+                if (null != srcInfo.getMinIndex()) {
+                    assertEquals(srcInfo.getMinIndex().getValue(), destInfo.getMinIndex().getValue());
+                    assertEquals(srcInfo.getMinIndex().getUom(), destInfo.getMinIndex().getUom());
+                }
+
+                // maxIndex
+                if (null != srcInfo.getMaxIndex()) {
+                    assertEquals(srcInfo.getMaxIndex().getValue(), destInfo.getMaxIndex().getValue());
+                    assertEquals(srcInfo.getMaxIndex().getUom(), destInfo.getMaxIndex().getUom());
+                }
+
+                // sensorOffset
+                if (null != srcInfo.getSensorOffset()) {
+                    assertEquals(srcInfo.getSensorOffset().getValue(), destInfo.getSensorOffset().getValue());
+                    assertEquals(srcInfo.getSensorOffset().getUom(), destInfo.getSensorOffset().getUom());
+                }
+
+                // densData
+                if (null != srcInfo.getDensData()) {
+                    assertEquals(srcInfo.getDensData().getValue(), destInfo.getDensData().getValue());
+                    assertEquals(srcInfo.getDensData().getUom(), destInfo.getDensData().getUom());
+                }
+
+                // traceState
+                if (null != srcInfo.getTraceState())
+                    assertEquals(srcInfo.getTraceState().value(), destInfo.getTraceState().value());
+
+                // traceOrigin
+                if (null != srcInfo.getTraceOrigin())
+                    assertEquals(srcInfo.getTraceOrigin().value(), destInfo.getTraceOrigin().value());
+
+                // typeLogData
+                if (null != srcInfo.getTypeLogData())
+                    assertEquals(srcInfo.getTypeLogData().value(), destInfo.getTypeLogData().value());
+
+                // repeating fields
+                if (null != srcInfo.getAxisDefinition()) {
+                    for (int j = 0; j < srcInfo.getAxisDefinition().size(); j++) {
+                        com.hashmapinc.tempus.WitsmlObjects.v1311.CsAxisDefinition srcDef = srcInfo.getAxisDefinition().get(j);
+                        com.hashmapinc.tempus.WitsmlObjects.v1411.CsAxisDefinition destDef = destInfo.getAxisDefinition().get(j);
+
+                        // simple fields
+                        assertEquals(srcDef.getOrder(), destDef.getOrder());
+                        assertEquals(srcDef.getCount(), destDef.getCount());
+                        assertEquals(srcDef.getName(), destDef.getName());
+                        assertEquals(srcDef.getPropertyType(), destDef.getPropertyType());
+                        assertEquals(srcDef.getUom(), destDef.getUom());
+                        assertEquals(srcDef.getUid(), destDef.getUid());
+                        assertEquals(srcDef.getDoubleValues(), destDef.getDoubleValues());
+                        assertEquals(srcDef.getStringValues(), destDef.getStringValues());
+                    }
+                }
+            }
+        }
     }
 
     public static com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog convertTo1411(com.hashmapinc.tempus.WitsmlObjects.v20.Log src) {

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
@@ -86,101 +86,24 @@ public class LogConverter {
         // check repeating fields
         // logParam
         if (null != src.getLogParam()) {
-            for (int i = 0; i < src.getLogParam().size(); i++) {
-                assertEquals(src.getLogParam().get(i).getDescription(), dest.getLogParam().get(i).getDescription());
-                assertEquals(src.getLogParam().get(i).getValue(), dest.getLogParam().get(i).getValue());
-                assertEquals(src.getLogParam().get(i).getIndex(), dest.getLogParam().get(i).getIndex());
-                assertEquals(src.getLogParam().get(i).getName(), dest.getLogParam().get(i).getName());
-                assertEquals(src.getLogParam().get(i).getUom(), dest.getLogParam().get(i).getUom());
-            }
+            List<com.hashmapinc.tempus.WitsmlObjects.v1411.IndexedObject> destParams = new ArrayList<>();
+            for (com.hashmapinc.tempus.WitsmlObjects.v1311.IndexedObject srcParam : src.getLogParam())
+                destParams.add(srcParam.to1411IndexedObject());
+
+            dest.setLogParam(destParams);
         }
 
-        // logParam
+        // logCurveInfo
         if (null != src.getLogCurveInfo()) {
-            for (int i = 0; i < src.getLogCurveInfo().size(); i++) {
-                com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo srcInfo = src.getLogCurveInfo().get(i);
-                com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo destInfo = dest.getLogCurveInfo().get(i);
+            List<com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo> destInfos = new ArrayList<>();
+            for (com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo srcInfo : src.getLogCurveInfo())
+                destInfos.add(srcInfo.to1411CsLogCurveInfo());
 
-                // simple fields
-                assertEquals(srcInfo.getClassWitsml(), destInfo.getClassWitsml());
-                assertEquals(srcInfo.getUnit(), destInfo.getUnit());
-                assertEquals(srcInfo.getNullValue(), destInfo.getNullValue());
-                assertEquals(srcInfo.isAlternateIndex(), destInfo.isAlternateIndex());
-                assertEquals(srcInfo.getMinDateTimeIndex(), destInfo.getMinDateTimeIndex());
-                assertEquals(srcInfo.getMaxDateTimeIndex(), destInfo.getMaxDateTimeIndex());
-                assertEquals(srcInfo.getCurveDescription(), destInfo.getCurveDescription());
-                assertEquals(srcInfo.getDataSource(), destInfo.getDataSource());
-                assertEquals(srcInfo.getUid(), destInfo.getUid());
-
-                // complex fields
-                // mnemonic
-                if (null != srcInfo.getMnemonic())
-                    assertEquals(srcInfo.getMnemonic(), destInfo.getMnemonic().getValue());
-
-                // mnemAlias
-                if (null != srcInfo.getMnemAlias())
-                    assertEquals(srcInfo.getMnemAlias(), destInfo.getMnemAlias().getValue());
-                // wellDatum
-                if (null != srcInfo.getWellDatum()) {
-                    assertEquals(srcInfo.getWellDatum().getValue(), destInfo.getWellDatum().getValue());
-                    assertEquals(srcInfo.getWellDatum().getUidRef(), destInfo.getWellDatum().getUidRef());
-                }
-
-                // minIndex
-                if (null != srcInfo.getMinIndex()) {
-                    assertEquals(srcInfo.getMinIndex().getValue(), destInfo.getMinIndex().getValue());
-                    assertEquals(srcInfo.getMinIndex().getUom(), destInfo.getMinIndex().getUom());
-                }
-
-                // maxIndex
-                if (null != srcInfo.getMaxIndex()) {
-                    assertEquals(srcInfo.getMaxIndex().getValue(), destInfo.getMaxIndex().getValue());
-                    assertEquals(srcInfo.getMaxIndex().getUom(), destInfo.getMaxIndex().getUom());
-                }
-
-                // sensorOffset
-                if (null != srcInfo.getSensorOffset()) {
-                    assertEquals(srcInfo.getSensorOffset().getValue(), destInfo.getSensorOffset().getValue());
-                    assertEquals(srcInfo.getSensorOffset().getUom(), destInfo.getSensorOffset().getUom());
-                }
-
-                // densData
-                if (null != srcInfo.getDensData()) {
-                    assertEquals(srcInfo.getDensData().getValue(), destInfo.getDensData().getValue());
-                    assertEquals(srcInfo.getDensData().getUom(), destInfo.getDensData().getUom());
-                }
-
-                // traceState
-                if (null != srcInfo.getTraceState())
-                    assertEquals(srcInfo.getTraceState().value(), destInfo.getTraceState().value());
-
-                // traceOrigin
-                if (null != srcInfo.getTraceOrigin())
-                    assertEquals(srcInfo.getTraceOrigin().value(), destInfo.getTraceOrigin().value());
-
-                // typeLogData
-                if (null != srcInfo.getTypeLogData())
-                    assertEquals(srcInfo.getTypeLogData().value(), destInfo.getTypeLogData().value());
-
-                // repeating fields
-                if (null != srcInfo.getAxisDefinition()) {
-                    for (int j = 0; j < srcInfo.getAxisDefinition().size(); j++) {
-                        com.hashmapinc.tempus.WitsmlObjects.v1311.CsAxisDefinition srcDef = srcInfo.getAxisDefinition().get(j);
-                        com.hashmapinc.tempus.WitsmlObjects.v1411.CsAxisDefinition destDef = destInfo.getAxisDefinition().get(j);
-
-                        // simple fields
-                        assertEquals(srcDef.getOrder(), destDef.getOrder());
-                        assertEquals(srcDef.getCount(), destDef.getCount());
-                        assertEquals(srcDef.getName(), destDef.getName());
-                        assertEquals(srcDef.getPropertyType(), destDef.getPropertyType());
-                        assertEquals(srcDef.getUom(), destDef.getUom());
-                        assertEquals(srcDef.getUid(), destDef.getUid());
-                        assertEquals(srcDef.getDoubleValues(), destDef.getDoubleValues());
-                        assertEquals(srcDef.getStringValues(), destDef.getStringValues());
-                    }
-                }
-            }
+            dest.setLogCurveInfo(destInfos);
         }
+
+
+        return dest;
     }
 
     public static com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog convertTo1411(com.hashmapinc.tempus.WitsmlObjects.v20.Log src) {

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
@@ -1,5 +1,8 @@
 package com.hashmapinc.tempus.WitsmlObjects.Util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class LogConverter {
     //=========================================================================
     // conversions to 1.3.1.1
@@ -42,54 +45,43 @@ public class LogConverter {
         // check complex fields
         // indexType
         if (null != src.getIndexType())
-            assertEquals(src.getIndexType().value(), dest.getIndexType().value());
+            dest.setIndexType(com.hashmapinc.tempus.WitsmlObjects.v1411.LogIndexType.fromValue(src.getIndexType().value()));
 
         // startIndex
-        if (null != src.getStartIndex()) {
-            assertEquals(src.getStartIndex().getUom(), dest.getStartIndex().getUom());
-            assertEquals(src.getStartIndex().getValue(), dest.getStartIndex().getValue());
-        }
+        if (null != src.getStartIndex())
+            dest.setStartIndex(src.getStartIndex().to1411GenericMeasure());
 
         // endIndex
-        if (null != src.getEndIndex()) {
-            assertEquals(src.getEndIndex().getUom(), dest.getEndIndex().getUom());
-            assertEquals(src.getEndIndex().getValue(), dest.getEndIndex().getValue());
-        }
+        if (null != src.getEndIndex())
+            dest.setEndIndex(src.getEndIndex().to1411GenericMeasure());
 
         // stepIncrement
-        if (null != src.getStepIncrement()) {
-            assertEquals(src.getStepIncrement().getUom(), dest.getStepIncrement().getUom());
-            assertEquals(src.getStepIncrement().getValue(), dest.getStepIncrement().getValue());
-            assertEquals(src.getStepIncrement().getNumerator(), dest.getStepIncrement().getNumerator());
-            assertEquals(src.getStepIncrement().getDenominator(), dest.getStepIncrement().getDenominator());
-        }
+        if (null != src.getStepIncrement())
+            dest.setStepIncrement(src.getStepIncrement().to1411RatioGenericMeasure());
 
         // direction
         if (null != src.getDirection())
-            assertEquals(src.getDirection().value(), dest.getDirection().value());
+            dest.setDirection(com.hashmapinc.tempus.WitsmlObjects.v1411.LogIndexDirection.fromValue(src.getDirection().value()));
 
         // indexCurve
         if (null != src.getIndexCurve())
-            assertEquals(src.getIndexCurve().getValue(), dest.getIndexCurve());
+            dest.setIndexCurve(src.getIndexCurve().getValue());
 
         // logData
-        if (null != src.getLogData())
-            assertEquals(src.getLogData().getData(), dest.getLogData().get(0).getData()); // TODO: confirm this conversion
+        if (null != src.getLogData()) { // TODO: confirm this conversion
+            List<com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogData> destLogData = new ArrayList<>();
+            destLogData.add(new com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogData());
+            destLogData.get(0).setData(src.getLogData().getData());
+            dest.setLogData(destLogData);
+        }
 
         // commonData
-        if (null != src.getCommonData()) {
-            assertEquals(src.getCommonData().getSourceName(), dest.getCommonData().getSourceName());
-            assertEquals(src.getCommonData().getDTimCreation(), dest.getCommonData().getDTimCreation());
-            assertEquals(src.getCommonData().getDTimLastChange(), dest.getCommonData().getDTimLastChange());
-            assertEquals(src.getCommonData().getItemState().value(), dest.getCommonData().getItemState().value());
-            assertEquals(src.getCommonData().getComments(), dest.getCommonData().getComments());
-        }
+        if (null != src.getCommonData())
+            dest.setCommonData(src.getCommonData().to1411CommonData());
 
         // customData
-        if (null != src.getCustomData() && null != src.getCustomData().getAny()){
-            for (int i = 0; i < src.getCustomData().getAny().size(); i++)
-                assertEquals(src.getCustomData().getAny().get(i), dest.getCustomData().getAny().get(i));
-        }
+        if (null != src.getCustomData() && null != src.getCustomData().getAny())
+            dest.setCustomData(src.getCustomData().to1411CustomData());
 
         // check repeating fields
         // logParam

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
@@ -1,0 +1,41 @@
+package com.hashmapinc.tempus.WitsmlObjects.Util;
+
+public class LogConverter {
+    //=========================================================================
+    // conversions to 1.3.1.1
+    //=========================================================================
+    public static com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog convertTo1311(com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog src) {
+        return null;
+    }
+
+    public static com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog convertTo1311(com.hashmapinc.tempus.WitsmlObjects.v20.Log src) {
+        return null;
+    }
+    //=========================================================================
+
+
+    //=========================================================================
+    // conversions to 1.4.1.1
+    //=========================================================================
+    public static com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog convertTo1411(com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog src) {
+        return null;
+    }
+
+    public static com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog convertTo1411(com.hashmapinc.tempus.WitsmlObjects.v20.Log src) {
+        return null;
+    }
+    //=========================================================================
+
+
+    //=========================================================================
+    // conversions to 2.0
+    //=========================================================================
+    public static com.hashmapinc.tempus.WitsmlObjects.v20.Log convertTo20(com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog src) {
+        return null;
+    }
+
+    public static com.hashmapinc.tempus.WitsmlObjects.v20.Log convertTo20(com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog src) {
+        return null;
+    }
+    //=========================================================================
+}

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverter.java
@@ -8,7 +8,91 @@ public class LogConverter {
     // conversions to 1.3.1.1
     //=========================================================================
     public static com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog convertTo1311(com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog src) {
-        return null;
+        // get converted log
+        com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog dest = new com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog();
+
+        // check equality for non complex, non repeating fields
+        dest.setNameWell(src.getNameWell());
+        dest.setNameWellbore(src.getNameWellbore());
+        dest.setName(src.getName());
+        dest.setObjectGrowing(src.isObjectGrowing());
+        dest.setServiceCompany(src.getServiceCompany());
+        dest.setRunNumber(src.getRunNumber());
+        dest.setBhaRunNumber(src.getBhaRunNumber());
+        dest.setPass(src.getPass());
+        dest.setUidWell(src.getUidWell());
+        dest.setUidWellbore(src.getUidWellbore());
+        dest.setUid(src.getUid());
+        dest.setCreationDate(src.getCreationDate());
+        dest.setDescription(src.getDescription());
+        dest.setNullValue(src.getNullValue());
+        dest.setStartDateTimeIndex(src.getStartDateTimeIndex());
+        dest.setEndDateTimeIndex(src.getEndDateTimeIndex());
+
+        // check complex fields
+        // indexType
+        if (null != src.getIndexType())
+            dest.setIndexType(com.hashmapinc.tempus.WitsmlObjects.v1311.LogIndexType.fromValue(src.getIndexType().value()));
+
+        // startIndex
+        if (null != src.getStartIndex())
+            dest.setStartIndex(src.getStartIndex().to1311GenericMeasure());
+
+        // endIndex
+        if (null != src.getEndIndex())
+            dest.setEndIndex(src.getEndIndex().to1311GenericMeasure());
+
+        // stepIncrement
+        if (null != src.getStepIncrement())
+            dest.setStepIncrement(src.getStepIncrement().to1311RatioGenericMeasure());
+
+        // direction
+        if (null != src.getDirection())
+            dest.setDirection(com.hashmapinc.tempus.WitsmlObjects.v1311.LogIndexDirection.fromValue(src.getDirection().value()));
+
+        // indexCurve
+        if (null != src.getIndexCurve()) {
+            com.hashmapinc.tempus.WitsmlObjects.v1311.IndexCurve destCurve = new com.hashmapinc.tempus.WitsmlObjects.v1311.IndexCurve();
+            destCurve.setValue(src.getIndexCurve());
+            dest.setIndexCurve(destCurve);
+        }
+
+        // logData
+        if (null != src.getLogData() && 0 < src.getLogData().size() && null != src.getLogData().get(0).getData()) { // TODO: confirm this conversion
+            com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogData destLogData = new com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogData();
+            destLogData.setData(src.getLogData().get(0).getData());
+            dest.setLogData(destLogData);
+        }
+
+        // commonData
+        if (null != src.getCommonData())
+            dest.setCommonData(src.getCommonData().to1311CommonData());
+
+        // customData
+        if (null != src.getCustomData() && null != src.getCustomData().getAny())
+            dest.setCustomData(src.getCustomData().to1311CustomData());
+
+        // check repeating fields
+        // logParam
+        if (null != src.getLogParam()) {
+            List<com.hashmapinc.tempus.WitsmlObjects.v1311.IndexedObject> destParams = new ArrayList<>();
+            for (com.hashmapinc.tempus.WitsmlObjects.v1411.IndexedObject srcParam : src.getLogParam())
+                destParams.add(srcParam.to1311IndexedObject());
+
+            dest.setLogParam(destParams);
+        }
+
+        // logCurveInfo
+        if (null != src.getLogCurveInfo()) {
+            List<com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo> destInfos = new ArrayList<>();
+            for (com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo srcInfo : src.getLogCurveInfo())
+                destInfos.add(srcInfo.to1311CsLogCurveInfo());
+
+            dest.setLogCurveInfo(destInfos);
+        }
+
+
+        return dest;
     }
 
     public static com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog convertTo1311(com.hashmapinc.tempus.WitsmlObjects.v20.Log src) {

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/CsAxisDefinition.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/CsAxisDefinition.java
@@ -202,6 +202,13 @@ public class CsAxisDefinition {
         return this.doubleValues;
     }
 
+    public void setDoubleValues(List<String> values) {
+        this.doubleValues = new ArrayList<>();
+        for (String value : values) {
+            this.doubleValues.add(Double.parseDouble(value));
+        }
+    }
+
     /**
      * Gets the value of the stringValues property.
      * 
@@ -231,6 +238,10 @@ public class CsAxisDefinition {
         return this.stringValues;
     }
 
+    public void setStringValues(List<String> values) {
+        this.stringValues = values;
+    }
+
     /**
      * Gets the value of the uid property.
      * 
@@ -254,5 +265,28 @@ public class CsAxisDefinition {
     public void setUid(String value) {
         this.uid = value;
     }
+
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1411.CsAxisDefinition to1411CsAxisDefinition() {
+        com.hashmapinc.tempus.WitsmlObjects.v1411.CsAxisDefinition def = new com.hashmapinc.tempus.WitsmlObjects.v1411.CsAxisDefinition();
+
+        // assign fields
+        def.setOrder(this.getOrder());
+        def.setCount(this.getCount());
+        def.setName(this.getName());
+        def.setPropertyType(this.getPropertyType());
+        def.setUom(this.getUom());
+        def.setUid(this.getUid());
+        def.setDoubleValues(this.getDoubleValues());
+        def.setStringValues(this.getStringValues());
+
+        return def;
+    }
+    //=========================================================================
 
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/CsLogCurveInfo.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/CsLogCurveInfo.java
@@ -583,6 +583,10 @@ public class CsLogCurveInfo {
         return this.axisDefinition;
     }
 
+    public void setAxisDefinition(List<CsAxisDefinition> values) {
+        this.axisDefinition = values;
+    }
+
     /**
      * Gets the value of the uid property.
      * 
@@ -606,5 +610,85 @@ public class CsLogCurveInfo {
     public void setUid(String value) {
         this.uid = value;
     }
+
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo to1411CsLogCurveInfo() {
+        com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo info = new com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo();
+
+        // simple fields
+        info.setClassWitsml(this.getClassWitsml());
+        info.setUnit(this.getUnit());
+        info.setNullValue(this.getNullValue());
+        info.setAlternateIndex(this.isAlternateIndex());
+        info.setMinDateTimeIndex(this.getMinDateTimeIndex());
+        info.setMaxDateTimeIndex(this.getMaxDateTimeIndex());
+        info.setCurveDescription(this.getCurveDescription());
+        info.setDataSource(this.getDataSource());
+        info.setUid(this.getUid());
+
+        // complex fields
+        // mnemonic
+        if (null != this.getMnemonic()) {
+            com.hashmapinc.tempus.WitsmlObjects.v1411.ShortNameStruct mnemonic = new com.hashmapinc.tempus.WitsmlObjects.v1411.ShortNameStruct();
+            mnemonic.setValue(this.getMnemonic());
+            info.setMnemonic(mnemonic);
+        }
+
+        // mnemAlias
+        if (null != this.getMnemAlias()) {
+            com.hashmapinc.tempus.WitsmlObjects.v1411.ShortNameStruct mnemAlias = new com.hashmapinc.tempus.WitsmlObjects.v1411.ShortNameStruct();
+            mnemAlias.setValue(this.getMnemAlias());
+            info.setMnemAlias(mnemAlias);
+        }
+
+        // wellDatum
+        if (null != this.getWellDatum())
+            info.setWellDatum(this.getWellDatum().to1411RefNameString());
+
+        // minIndex
+        if (null != this.getMinIndex())
+            info.setMinIndex(this.getMinIndex().to1411GenericMeasure());
+
+        // maxIndex
+        if (null != this.getMaxIndex())
+            info.setMaxIndex(this.getMaxIndex().to1411GenericMeasure());
+
+        // sensorOffset
+        if (null != this.getSensorOffset())
+            info.setSensorOffset(this.getSensorOffset().to1411Length());
+
+        // densData
+        if (null != this.getDensData())
+            info.setDensData(this.getDensData().to1411PerLengthMeasure());
+
+        // traceState
+        if (null != this.getTraceState())
+            info.setTraceState(com.hashmapinc.tempus.WitsmlObjects.v1411.LogTraceState.fromValue(this.getTraceState().value()));
+
+        // traceOrigin
+        if (null != this.getTraceOrigin())
+            info.setTraceOrigin(com.hashmapinc.tempus.WitsmlObjects.v1411.LogTraceOrigin.fromValue(this.getTraceOrigin().value()));
+
+        // typeLogData
+        if (null != this.getTypeLogData())
+            info.setTypeLogData(com.hashmapinc.tempus.WitsmlObjects.v1411.LogDataType.fromValue(this.getTypeLogData().value()));
+
+        // repeating fields
+        if (null != this.getAxisDefinition()) {
+            List<com.hashmapinc.tempus.WitsmlObjects.v1411.CsAxisDefinition> destDefs = new ArrayList<>();
+            for (com.hashmapinc.tempus.WitsmlObjects.v1311.CsAxisDefinition srcDef : this.getAxisDefinition())
+                destDefs.add(srcDef.to1411CsAxisDefinition());
+
+            info.setAxisDefinition(destDefs);
+        }
+
+        return info;
+    }
+    //=========================================================================
 
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/CsLogData.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/CsLogData.java
@@ -66,4 +66,8 @@ public class CsLogData {
         return this.data;
     }
 
+    public void setData(List<String> values) {
+        this.data = values;
+    }
+
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/GenericMeasure.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/GenericMeasure.java
@@ -60,4 +60,21 @@ public class GenericMeasure
         this.uom = value;
     }
 
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1411.GenericMeasure to1411GenericMeasure() {
+        com.hashmapinc.tempus.WitsmlObjects.v1411.GenericMeasure measure = new com.hashmapinc.tempus.WitsmlObjects.v1411.GenericMeasure();
+
+        // assign fields
+        measure.setValue(this.getValue());
+        measure.setUom(this.getUom());
+
+        return measure;
+    }
+    //=========================================================================
+
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/ObjLog.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/ObjLog.java
@@ -549,6 +549,10 @@ public class ObjLog extends AbstractWitsmlObject {
         return this.logParam;
     }
 
+    public void setLogParam(List<IndexedObject> value) {
+        this.logParam = value;
+    }
+
     /**
      * Gets the value of the logCurveInfo property.
      *
@@ -574,6 +578,10 @@ public class ObjLog extends AbstractWitsmlObject {
             logCurveInfo = new ArrayList<CsLogCurveInfo>();
         }
         return this.logCurveInfo;
+    }
+
+    public void setLogCurveInfo(List<CsLogCurveInfo> values) {
+        this.logCurveInfo = values;
     }
 
     /**

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/PerLengthMeasure.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/PerLengthMeasure.java
@@ -56,4 +56,21 @@ public class PerLengthMeasure
         this.uom = value;
     }
 
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1411.PerLengthMeasure to1411PerLengthMeasure() {
+        com.hashmapinc.tempus.WitsmlObjects.v1411.PerLengthMeasure measure = new com.hashmapinc.tempus.WitsmlObjects.v1411.PerLengthMeasure();
+
+        // assign fields
+        measure.setValue(this.getValue());
+        measure.setUom(this.getUom());
+
+        return measure;
+    }
+    //=========================================================================
+
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/RatioGenericMeasure.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/RatioGenericMeasure.java
@@ -120,4 +120,22 @@ public class RatioGenericMeasure
         this.denominator = value;
     }
 
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1411.RatioGenericMeasure to1411RatioGenericMeasure() {
+        com.hashmapinc.tempus.WitsmlObjects.v1411.RatioGenericMeasure measure = new com.hashmapinc.tempus.WitsmlObjects.v1411.RatioGenericMeasure();
+
+        measure.setValue(this.getValue());
+        measure.setUom(this.getUom());
+        measure.setDenominator(this.getDenominator());
+        measure.setNumerator(this.getNumerator());
+
+        return measure;
+    }
+    //=========================================================================
+
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/CsAxisDefinition.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/CsAxisDefinition.java
@@ -209,6 +209,12 @@ public class CsAxisDefinition {
         return this.doubleValues;
     }
 
+    public void setDoubleValues(List<Double> values) {
+        this.doubleValues = new ArrayList<>();
+        for (Double value : values)
+            this.doubleValues.add(value.toString());
+    }
+
     /**
      * Gets the value of the stringValues property.
      * 
@@ -236,6 +242,10 @@ public class CsAxisDefinition {
             stringValues = new ArrayList<String>();
         }
         return this.stringValues;
+    }
+
+    public void setStringValues(List<String> values) {
+        this.stringValues = values;
     }
 
     /**
@@ -290,5 +300,28 @@ public class CsAxisDefinition {
     public void setUid(String value) {
         this.uid = value;
     }
+
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1311.CsAxisDefinition to1311CsAxisDefinition() {
+        com.hashmapinc.tempus.WitsmlObjects.v1311.CsAxisDefinition def = new com.hashmapinc.tempus.WitsmlObjects.v1311.CsAxisDefinition();
+
+        // assign fields
+        def.setOrder(this.getOrder());
+        def.setCount(this.getCount());
+        def.setName(this.getName());
+        def.setPropertyType(this.getPropertyType());
+        def.setUom(this.getUom());
+        def.setUid(this.getUid());
+        def.setDoubleValues(this.getDoubleValues());
+        def.setStringValues(this.getStringValues());
+
+        return def;
+    }
+    //=========================================================================
 
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/CsLogCurveInfo.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/CsLogCurveInfo.java
@@ -683,11 +683,11 @@ public class CsLogCurveInfo {
         // complex fields
         // mnemonic
         if (null != this.getMnemonic())
-            mnemonic.setValue(this.getMnemonic().getValue());
+            info.setMnemonic(this.getMnemonic().getValue());
 
         // mnemAlias
         if (null != this.getMnemAlias())
-            mnemAlias.setValue(this.getMnemonic().getValue());
+            info.setMnemAlias(this.getMnemAlias().getValue());
 
         // wellDatum
         if (null != this.getWellDatum())

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/CsLogCurveInfo.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/CsLogCurveInfo.java
@@ -603,6 +603,10 @@ public class CsLogCurveInfo {
         return this.axisDefinition;
     }
 
+    public void setAxisDefinition(List<CsAxisDefinition> values) {
+        this.axisDefinition = values;
+    }
+
     /**
      * Gets the value of the extensionNameValue property.
      * 
@@ -655,5 +659,79 @@ public class CsLogCurveInfo {
     public void setUid(String value) {
         this.uid = value;
     }
+
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo to1311CsLogCurveInfo() {
+        com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo info = new com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo();
+
+        // simple fields
+        info.setClassWitsml(this.getClassWitsml());
+        info.setUnit(this.getUnit());
+        info.setNullValue(this.getNullValue());
+        info.setAlternateIndex(this.isAlternateIndex());
+        info.setMinDateTimeIndex(this.getMinDateTimeIndex());
+        info.setMaxDateTimeIndex(this.getMaxDateTimeIndex());
+        info.setCurveDescription(this.getCurveDescription());
+        info.setDataSource(this.getDataSource());
+        info.setUid(this.getUid());
+
+        // complex fields
+        // mnemonic
+        if (null != this.getMnemonic())
+            mnemonic.setValue(this.getMnemonic().getValue());
+
+        // mnemAlias
+        if (null != this.getMnemAlias())
+            mnemAlias.setValue(this.getMnemonic().getValue());
+
+        // wellDatum
+        if (null != this.getWellDatum())
+            info.setWellDatum(this.getWellDatum().to1311RefNameString());
+
+        // minIndex
+        if (null != this.getMinIndex())
+            info.setMinIndex(this.getMinIndex().to1311GenericMeasure());
+
+        // maxIndex
+        if (null != this.getMaxIndex())
+            info.setMaxIndex(this.getMaxIndex().to1311GenericMeasure());
+
+        // sensorOffset
+        if (null != this.getSensorOffset())
+            info.setSensorOffset(this.getSensorOffset().to1311LengthMeasure());
+
+        // densData
+        if (null != this.getDensData())
+            info.setDensData(this.getDensData().to1311PerLengthMeasure());
+
+        // traceState
+        if (null != this.getTraceState())
+            info.setTraceState(com.hashmapinc.tempus.WitsmlObjects.v1311.LogTraceState.fromValue(this.getTraceState().value()));
+
+        // traceOrigin
+        if (null != this.getTraceOrigin())
+            info.setTraceOrigin(com.hashmapinc.tempus.WitsmlObjects.v1311.LogTraceOrigin.fromValue(this.getTraceOrigin().value()));
+
+        // typeLogData
+        if (null != this.getTypeLogData())
+            info.setTypeLogData(com.hashmapinc.tempus.WitsmlObjects.v1311.LogDataType.fromValue(this.getTypeLogData().value()));
+
+        // repeating fields
+        if (null != this.getAxisDefinition()) {
+            List<com.hashmapinc.tempus.WitsmlObjects.v1311.CsAxisDefinition> destDefs = new ArrayList<>();
+            for (com.hashmapinc.tempus.WitsmlObjects.v1411.CsAxisDefinition srcDef : this.getAxisDefinition())
+                destDefs.add(srcDef.to1311CsAxisDefinition());
+
+            info.setAxisDefinition(destDefs);
+        }
+
+        return info;
+    }
+    //=========================================================================
 
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/CsLogData.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/CsLogData.java
@@ -131,4 +131,8 @@ public class CsLogData {
         return this.data;
     }
 
+
+    public void setData(List<String> value) {
+        this.data = value;
+    }
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/GenericMeasure.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/GenericMeasure.java
@@ -68,4 +68,21 @@ public class GenericMeasure
         this.uom = value;
     }
 
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1311.GenericMeasure to1311GenericMeasure() {
+        com.hashmapinc.tempus.WitsmlObjects.v1311.GenericMeasure measure = new com.hashmapinc.tempus.WitsmlObjects.v1311.GenericMeasure();
+
+        // assign fields
+        measure.setValue(this.getValue());
+        measure.setUom(this.getUom());
+
+        return measure;
+    }
+    //=========================================================================
+
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/ObjLog.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/ObjLog.java
@@ -774,6 +774,10 @@ public class ObjLog extends AbstractWitsmlObject {
         return this.logData;
     }
 
+    public void setLogData(List<CsLogData> dataList) {
+        this.logData = dataList;
+    }
+
     /**
      * Gets the value of the commonData property.
      * 

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/ObjLog.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/ObjLog.java
@@ -716,6 +716,10 @@ public class ObjLog extends AbstractWitsmlObject {
         return this.logParam;
     }
 
+    public void setLogParam(List<IndexedObject> value) {
+        this.logParam = value;
+    }
+
     /**
      * Gets the value of the logCurveInfo property.
      * 
@@ -743,6 +747,10 @@ public class ObjLog extends AbstractWitsmlObject {
             logCurveInfo = new ArrayList<CsLogCurveInfo>();
         }
         return this.logCurveInfo;
+    }
+
+    public void setLogCurveInfo(List<CsLogCurveInfo> values) {
+        this.logCurveInfo = values;
     }
 
     /**

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/PerLengthMeasure.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/PerLengthMeasure.java
@@ -64,4 +64,21 @@ public class PerLengthMeasure
         this.uom = value;
     }
 
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1311.PerLengthMeasure to1311PerLengthMeasure() {
+        com.hashmapinc.tempus.WitsmlObjects.v1311.PerLengthMeasure measure = new com.hashmapinc.tempus.WitsmlObjects.v1311.PerLengthMeasure();
+
+        // assign fields
+        measure.setValue(this.getValue());
+        measure.setUom(this.getUom());
+
+        return measure;
+    }
+    //=========================================================================
+
 }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/RatioGenericMeasure.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/RatioGenericMeasure.java
@@ -128,4 +128,22 @@ public class RatioGenericMeasure
         this.denominator = value;
     }
 
+
+
+
+    //=========================================================================
+    // conversion methods for 1.3.1.1/1.4.1.1/2.0 interop
+    //=========================================================================
+    public com.hashmapinc.tempus.WitsmlObjects.v1311.RatioGenericMeasure to1311RatioGenericMeasure() {
+        com.hashmapinc.tempus.WitsmlObjects.v1311.RatioGenericMeasure measure = new com.hashmapinc.tempus.WitsmlObjects.v1311.RatioGenericMeasure();
+
+        measure.setValue(this.getValue());
+        measure.setUom(this.getUom());
+        measure.setDenominator(this.getDenominator());
+        measure.setNumerator(this.getNumerator());
+
+        return measure;
+    }
+    //=========================================================================
+
 }

--- a/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
+++ b/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
@@ -99,7 +99,7 @@ public class LogConverterTest {
             }
         }
 
-        // logParam
+        // logCurveInfo
         if (null != src.getLogCurveInfo()) {
             for (int i = 0; i < src.getLogCurveInfo().size(); i++) {
                 com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo srcInfo = src.getLogCurveInfo().get(i);
@@ -300,7 +300,7 @@ public class LogConverterTest {
             }
         }
 
-        // logParam
+        // logCurveInfo
         if (null != src.getLogCurveInfo()) {
             for (int i = 0; i < src.getLogCurveInfo().size(); i++) {
                 com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo srcInfo = src.getLogCurveInfo().get(i);
@@ -325,6 +325,7 @@ public class LogConverterTest {
                 // mnemAlias
                 if (null != srcInfo.getMnemAlias())
                     assertEquals(srcInfo.getMnemAlias(), destInfo.getMnemAlias().getValue());
+
                 // wellDatum
                 if (null != srcInfo.getWellDatum()) {
                     assertEquals(srcInfo.getWellDatum().getValue(), destInfo.getWellDatum().getValue());

--- a/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
+++ b/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
@@ -2,6 +2,8 @@ package com.hashmapinc.tempus.WitsmlObjects.Util;
 
 import org.junit.Test;
 
+import static junit.framework.TestCase.assertEquals;
+
 public class LogConverterTest {
     //=========================================================================
     // conversions to 1.3.1.1
@@ -52,10 +54,79 @@ public class LogConverterTest {
         com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog dest = LogConverter.convertTo1411(src);
 
         // check equality for non complex, non repeating fields
+        assertEquals(src.getNameWell(), dest.getNameWell());
+        assertEquals(src.getNameWellbore(), dest.getNameWellbore());
+        assertEquals(src.getName(), dest.getName());
+        assertEquals(src.isObjectGrowing(), dest.isObjectGrowing());
+        assertEquals(src.getServiceCompany(), dest.getServiceCompany());
+        assertEquals(src.getRunNumber(), dest.getRunNumber());
+        assertEquals(src.getBhaRunNumber(), dest.getBhaRunNumber());
+        assertEquals(src.getPass(), dest.getPass());
+        assertEquals(src.getUidWell(), dest.getUidWell());
+        assertEquals(src.getUidWellbore(), dest.getUidWellbore());
+        assertEquals(src.getUid(), dest.getUid());
+        assertEquals(src.getCreationDate(), dest.getCreationDate());
+        assertEquals(src.getDescription(), dest.getDescription());
+        assertEquals(src.getNullValue(), dest.getNullValue());
+        assertEquals(src.getStartDateTimeIndex(), dest.getStartDateTimeIndex());
+        assertEquals(src.getEndDateTimeIndex(), dest.getEndDateTimeIndex());
+
 
         // check complex fields
+        // indexType
+        if (null != src.getIndexType())
+            assertEquals(src.getIndexType().value(), dest.getIndexType().value());
+
+        // startIndex
+        if (null != src.getStartIndex()) {
+            assertEquals(src.getStartIndex().getUom(), dest.getStartIndex().getUom());
+            assertEquals(src.getStartIndex().getValue(), dest.getStartIndex().getValue());
+        }
+
+        // endIndex
+        if (null != src.getEndIndex()) {
+            assertEquals(src.getEndIndex().getUom(), dest.getEndIndex().getUom());
+            assertEquals(src.getEndIndex().getValue(), dest.getEndIndex().getValue());
+        }
+
+        // stepIncrement
+        if (null != src.getStepIncrement()) {
+            assertEquals(src.getStepIncrement().getUom(), dest.getStepIncrement().getUom());
+            assertEquals(src.getStepIncrement().getValue(), dest.getStepIncrement().getValue());
+            assertEquals(src.getStepIncrement().getNumerator(), dest.getStepIncrement().getNumerator());
+            assertEquals(src.getStepIncrement().getDenominator(), dest.getStepIncrement().getDenominator());
+        }
+
+        // direction
+        if (null != src.getDirection())
+            assertEquals(src.getDirection().value(), dest.getDirection().value());
+
+        // indexCurve
+        if (null != src.getIndexCurve())
+            assertEquals(src.getIndexCurve().getValue(), dest.getIndexCurve());
+
+        // logData
+        if (null != src.getLogData())
+            assertEquals(src.getLogData().getData(), dest.getLogData().get(0).getData()); // TODO: confirm this conversion
+
+        // commonData
+        if (null != src.getCommonData()) {
+            assertEquals(src.getCommonData().getSourceName(), dest.getCommonData().getSourceName());
+            assertEquals(src.getCommonData().getDTimCreation(), dest.getCommonData().getDTimCreation());
+            assertEquals(src.getCommonData().getDTimLastChange(), dest.getCommonData().getDTimLastChange());
+            assertEquals(src.getCommonData().getItemState().value(), dest.getCommonData().getItemState().value());
+            assertEquals(src.getCommonData().getComments(), dest.getCommonData().getComments());
+        }
+
+        // customData
+        if (null != src.getCustomData() && null != src.getCustomData().getAny()){
+            for (int i = 0; i < src.getCustomData().getAny().size(); i++)
+                assertEquals(src.getCustomData().getAny().get(i), dest.getCustomData().getAny().get(i));
+        }
 
         // check repeating fields
+        private List<IndexedObject> logParam;
+        private List<CsLogCurveInfo> logCurveInfo;
 
     }
 

--- a/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
+++ b/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
@@ -17,11 +17,175 @@ public class LogConverterTest {
         com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog dest = LogConverter.convertTo1311(src);
 
         // check equality for non complex, non repeating fields
+        assertEquals(src.getNameWell(), dest.getNameWell());
+        assertEquals(src.getNameWellbore(), dest.getNameWellbore());
+        assertEquals(src.getName(), dest.getName());
+        assertEquals(src.isObjectGrowing(), dest.isObjectGrowing());
+        assertEquals(src.getServiceCompany(), dest.getServiceCompany());
+        assertEquals(src.getRunNumber(), dest.getRunNumber());
+        assertEquals(src.getBhaRunNumber(), dest.getBhaRunNumber());
+        assertEquals(src.getPass(), dest.getPass());
+        assertEquals(src.getUidWell(), dest.getUidWell());
+        assertEquals(src.getUidWellbore(), dest.getUidWellbore());
+        assertEquals(src.getUid(), dest.getUid());
+        assertEquals(src.getCreationDate(), dest.getCreationDate());
+        assertEquals(src.getDescription(), dest.getDescription());
+        assertEquals(src.getNullValue(), dest.getNullValue());
+        assertEquals(src.getStartDateTimeIndex(), dest.getStartDateTimeIndex());
+        assertEquals(src.getEndDateTimeIndex(), dest.getEndDateTimeIndex());
+
 
         // check complex fields
+        // indexType
+        if (null != src.getIndexType())
+            assertEquals(src.getIndexType().value(), dest.getIndexType().value());
+
+        // startIndex
+        if (null != src.getStartIndex()) {
+            assertEquals(src.getStartIndex().getUom(), dest.getStartIndex().getUom());
+            assertEquals(src.getStartIndex().getValue(), dest.getStartIndex().getValue());
+        }
+
+        // endIndex
+        if (null != src.getEndIndex()) {
+            assertEquals(src.getEndIndex().getUom(), dest.getEndIndex().getUom());
+            assertEquals(src.getEndIndex().getValue(), dest.getEndIndex().getValue());
+        }
+
+        // stepIncrement
+        if (null != src.getStepIncrement()) {
+            assertEquals(src.getStepIncrement().getUom(), dest.getStepIncrement().getUom());
+            assertEquals(src.getStepIncrement().getValue(), dest.getStepIncrement().getValue());
+            assertEquals(src.getStepIncrement().getNumerator(), dest.getStepIncrement().getNumerator());
+            assertEquals(src.getStepIncrement().getDenominator(), dest.getStepIncrement().getDenominator());
+        }
+
+        // direction
+        if (null != src.getDirection())
+            assertEquals(src.getDirection().value(), dest.getDirection().value());
+
+        // indexCurve
+        if (null != src.getIndexCurve())
+            assertEquals(src.getIndexCurve(), dest.getIndexCurve().getValue());
+
+        // logData
+        if (null != src.getLogData())
+            assertEquals(src.getLogData().get(0).getData(), dest.getLogData().getData()); // TODO: confirm this conversion
+
+        // commonData
+        if (null != src.getCommonData()) {
+            assertEquals(src.getCommonData().getSourceName(), dest.getCommonData().getSourceName());
+            assertEquals(src.getCommonData().getDTimCreation(), dest.getCommonData().getDTimCreation());
+            assertEquals(src.getCommonData().getDTimLastChange(), dest.getCommonData().getDTimLastChange());
+            assertEquals(src.getCommonData().getItemState().value(), dest.getCommonData().getItemState().value());
+            assertEquals(src.getCommonData().getComments(), dest.getCommonData().getComments());
+        }
+
+        // customData
+        if (null != src.getCustomData() && null != src.getCustomData().getAny()){
+            for (int i = 0; i < src.getCustomData().getAny().size(); i++)
+                assertEquals(src.getCustomData().getAny().get(i), dest.getCustomData().getAny().get(i));
+        }
 
         // check repeating fields
+        // logParam
+        if (null != src.getLogParam()) {
+            for (int i = 0; i < src.getLogParam().size(); i++) {
+                assertEquals(src.getLogParam().get(i).getDescription(), dest.getLogParam().get(i).getDescription());
+                assertEquals(src.getLogParam().get(i).getValue(), dest.getLogParam().get(i).getValue());
+                assertEquals(src.getLogParam().get(i).getIndex(), dest.getLogParam().get(i).getIndex());
+                assertEquals(src.getLogParam().get(i).getName(), dest.getLogParam().get(i).getName());
+                assertEquals(src.getLogParam().get(i).getUom(), dest.getLogParam().get(i).getUom());
+            }
+        }
 
+        // logParam
+        if (null != src.getLogCurveInfo()) {
+            for (int i = 0; i < src.getLogCurveInfo().size(); i++) {
+                com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo srcInfo = src.getLogCurveInfo().get(i);
+                com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo destInfo = dest.getLogCurveInfo().get(i);
+
+                // simple fields
+                assertEquals(srcInfo.getClassWitsml(), destInfo.getClassWitsml());
+                assertEquals(srcInfo.getUnit(), destInfo.getUnit());
+                assertEquals(srcInfo.getNullValue(), destInfo.getNullValue());
+                assertEquals(srcInfo.isAlternateIndex(), destInfo.isAlternateIndex());
+                assertEquals(srcInfo.getMinDateTimeIndex(), destInfo.getMinDateTimeIndex());
+                assertEquals(srcInfo.getMaxDateTimeIndex(), destInfo.getMaxDateTimeIndex());
+                assertEquals(srcInfo.getCurveDescription(), destInfo.getCurveDescription());
+                assertEquals(srcInfo.getDataSource(), destInfo.getDataSource());
+                assertEquals(srcInfo.getUid(), destInfo.getUid());
+
+                // complex fields
+                // mnemonic
+                if (null != srcInfo.getMnemonic())
+                    assertEquals(srcInfo.getMnemonic().getValue(), destInfo.getMnemonic());
+
+                // mnemAlias
+                if (null != srcInfo.getMnemAlias())
+                    assertEquals(srcInfo.getMnemAlias().getValue(), destInfo.getMnemAlias());
+
+                // wellDatum
+                if (null != srcInfo.getWellDatum()) {
+                    assertEquals(srcInfo.getWellDatum().getValue(), destInfo.getWellDatum().getValue());
+                    assertEquals(srcInfo.getWellDatum().getUidRef(), destInfo.getWellDatum().getUidRef());
+                }
+
+                // minIndex
+                if (null != srcInfo.getMinIndex()) {
+                    assertEquals(srcInfo.getMinIndex().getValue(), destInfo.getMinIndex().getValue());
+                    assertEquals(srcInfo.getMinIndex().getUom(), destInfo.getMinIndex().getUom());
+                }
+
+                // maxIndex
+                if (null != srcInfo.getMaxIndex()) {
+                    assertEquals(srcInfo.getMaxIndex().getValue(), destInfo.getMaxIndex().getValue());
+                    assertEquals(srcInfo.getMaxIndex().getUom(), destInfo.getMaxIndex().getUom());
+                }
+
+                // sensorOffset
+                if (null != srcInfo.getSensorOffset()) {
+                    assertEquals(srcInfo.getSensorOffset().getValue(), destInfo.getSensorOffset().getValue());
+                    assertEquals(srcInfo.getSensorOffset().getUom(), destInfo.getSensorOffset().getUom());
+                }
+
+                // densData
+                if (null != srcInfo.getDensData()) {
+                    assertEquals(srcInfo.getDensData().getValue(), destInfo.getDensData().getValue());
+                    assertEquals(srcInfo.getDensData().getUom(), destInfo.getDensData().getUom());
+                }
+
+                // traceState
+                if (null != srcInfo.getTraceState())
+                    assertEquals(srcInfo.getTraceState().value(), destInfo.getTraceState().value());
+
+                // traceOrigin
+                if (null != srcInfo.getTraceOrigin())
+                    assertEquals(srcInfo.getTraceOrigin().value(), destInfo.getTraceOrigin().value());
+
+                // typeLogData
+                if (null != srcInfo.getTypeLogData())
+                    assertEquals(srcInfo.getTypeLogData().value(), destInfo.getTypeLogData().value());
+
+                // repeating fields
+                if (null != srcInfo.getAxisDefinition()) {
+                    for (int j = 0; j < srcInfo.getAxisDefinition().size(); j++) {
+                        com.hashmapinc.tempus.WitsmlObjects.v1411.CsAxisDefinition srcDef = srcInfo.getAxisDefinition().get(j);
+                        com.hashmapinc.tempus.WitsmlObjects.v1311.CsAxisDefinition destDef = destInfo.getAxisDefinition().get(j);
+
+                        // simple fields
+                        assertEquals(srcDef.getOrder(), destDef.getOrder());
+                        assertEquals(srcDef.getCount(), destDef.getCount());
+                        assertEquals(srcDef.getName(), destDef.getName());
+                        assertEquals(srcDef.getPropertyType(), destDef.getPropertyType());
+                        assertEquals(srcDef.getUom(), destDef.getUom());
+                        assertEquals(srcDef.getUid(), destDef.getUid());
+                        assertEquals(srcDef.getDoubleValues(), destDef.getDoubleValues());
+                        assertEquals(srcDef.getStringValues(), destDef.getStringValues());
+                    }
+                }
+            }
+        }
     }
 
     @Test
@@ -136,7 +300,6 @@ public class LogConverterTest {
             }
         }
 
-        private List<CsLogCurveInfo> logCurveInfo;
         // logParam
         if (null != src.getLogCurveInfo()) {
             for (int i = 0; i < src.getLogCurveInfo().size(); i++) {
@@ -144,10 +307,8 @@ public class LogConverterTest {
                 com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo destInfo = dest.getLogCurveInfo().get(i);
 
                 // simple fields
-                assertEquals(srcInfo.getMnemonic(), destInfo.getMnemonic());
                 assertEquals(srcInfo.getClassWitsml(), destInfo.getClassWitsml());
                 assertEquals(srcInfo.getUnit(), destInfo.getUnit());
-                assertEquals(srcInfo.getMnemAlias(), destInfo.getMnemAlias());
                 assertEquals(srcInfo.getNullValue(), destInfo.getNullValue());
                 assertEquals(srcInfo.isAlternateIndex(), destInfo.isAlternateIndex());
                 assertEquals(srcInfo.getMinDateTimeIndex(), destInfo.getMinDateTimeIndex());
@@ -157,6 +318,13 @@ public class LogConverterTest {
                 assertEquals(srcInfo.getUid(), destInfo.getUid());
 
                 // complex fields
+                // mnemonic
+                if (null != srcInfo.getMnemonic())
+                    assertEquals(srcInfo.getMnemonic(), destInfo.getMnemonic().getValue());
+
+                // mnemAlias
+                if (null != srcInfo.getMnemAlias())
+                    assertEquals(srcInfo.getMnemAlias(), destInfo.getMnemAlias().getValue());
                 // wellDatum
                 if (null != srcInfo.getWellDatum()) {
                     assertEquals(srcInfo.getWellDatum().getValue(), destInfo.getWellDatum().getValue());
@@ -218,7 +386,6 @@ public class LogConverterTest {
                 }
             }
         }
-
     }
 
     @Test

--- a/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
+++ b/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
@@ -125,8 +125,99 @@ public class LogConverterTest {
         }
 
         // check repeating fields
-        private List<IndexedObject> logParam;
+        // logParam
+        if (null != src.getLogParam()) {
+            for (int i = 0; i < src.getLogParam().size(); i++) {
+                assertEquals(src.getLogParam().get(i).getDescription(), dest.getLogParam().get(i).getDescription());
+                assertEquals(src.getLogParam().get(i).getValue(), dest.getLogParam().get(i).getValue());
+                assertEquals(src.getLogParam().get(i).getIndex(), dest.getLogParam().get(i).getIndex());
+                assertEquals(src.getLogParam().get(i).getName(), dest.getLogParam().get(i).getName());
+                assertEquals(src.getLogParam().get(i).getUom(), dest.getLogParam().get(i).getUom());
+            }
+        }
+
         private List<CsLogCurveInfo> logCurveInfo;
+        // logParam
+        if (null != src.getLogCurveInfo()) {
+            for (int i = 0; i < src.getLogCurveInfo().size(); i++) {
+                com.hashmapinc.tempus.WitsmlObjects.v1311.CsLogCurveInfo srcInfo = src.getLogCurveInfo().get(i);
+                com.hashmapinc.tempus.WitsmlObjects.v1411.CsLogCurveInfo destInfo = dest.getLogCurveInfo().get(i);
+
+                // simple fields
+                assertEquals(srcInfo.getMnemonic(), destInfo.getMnemonic());
+                assertEquals(srcInfo.getClassWitsml(), destInfo.getClassWitsml());
+                assertEquals(srcInfo.getUnit(), destInfo.getUnit());
+                assertEquals(srcInfo.getMnemAlias(), destInfo.getMnemAlias());
+                assertEquals(srcInfo.getNullValue(), destInfo.getNullValue());
+                assertEquals(srcInfo.isAlternateIndex(), destInfo.isAlternateIndex());
+                assertEquals(srcInfo.getMinDateTimeIndex(), destInfo.getMinDateTimeIndex());
+                assertEquals(srcInfo.getMaxDateTimeIndex(), destInfo.getMaxDateTimeIndex());
+                assertEquals(srcInfo.getCurveDescription(), destInfo.getCurveDescription());
+                assertEquals(srcInfo.getDataSource(), destInfo.getDataSource());
+                assertEquals(srcInfo.getUid(), destInfo.getUid());
+
+                // complex fields
+                // wellDatum
+                if (null != srcInfo.getWellDatum()) {
+                    assertEquals(srcInfo.getWellDatum().getValue(), destInfo.getWellDatum().getValue());
+                    assertEquals(srcInfo.getWellDatum().getUidRef(), destInfo.getWellDatum().getUidRef());
+                }
+
+                // minIndex
+                if (null != srcInfo.getMinIndex()) {
+                    assertEquals(srcInfo.getMinIndex().getValue(), destInfo.getMinIndex().getValue());
+                    assertEquals(srcInfo.getMinIndex().getUom(), destInfo.getMinIndex().getUom());
+                }
+
+                // maxIndex
+                if (null != srcInfo.getMaxIndex()) {
+                    assertEquals(srcInfo.getMaxIndex().getValue(), destInfo.getMaxIndex().getValue());
+                    assertEquals(srcInfo.getMaxIndex().getUom(), destInfo.getMaxIndex().getUom());
+                }
+
+                // sensorOffset
+                if (null != srcInfo.getSensorOffset()) {
+                    assertEquals(srcInfo.getSensorOffset().getValue(), destInfo.getSensorOffset().getValue());
+                    assertEquals(srcInfo.getSensorOffset().getUom(), destInfo.getSensorOffset().getUom());
+                }
+
+                // densData
+                if (null != srcInfo.getDensData()) {
+                    assertEquals(srcInfo.getDensData().getValue(), destInfo.getDensData().getValue());
+                    assertEquals(srcInfo.getDensData().getUom(), destInfo.getDensData().getUom());
+                }
+
+                // traceState
+                if (null != srcInfo.getTraceState())
+                    assertEquals(srcInfo.getTraceState().value(), destInfo.getTraceState().value());
+
+                // traceOrigin
+                if (null != srcInfo.getTraceOrigin())
+                    assertEquals(srcInfo.getTraceOrigin().value(), destInfo.getTraceOrigin().value());
+
+                // typeLogData
+                if (null != srcInfo.getTypeLogData())
+                    assertEquals(srcInfo.getTypeLogData().value(), destInfo.getTypeLogData().value());
+
+                // repeating fields
+                if (null != srcInfo.getAxisDefinition()) {
+                    for (int j = 0; j < srcInfo.getAxisDefinition().size(); j++) {
+                        com.hashmapinc.tempus.WitsmlObjects.v1311.CsAxisDefinition srcDef = srcInfo.getAxisDefinition().get(j);
+                        com.hashmapinc.tempus.WitsmlObjects.v1411.CsAxisDefinition destDef = destInfo.getAxisDefinition().get(j);
+
+                        // simple fields
+                        assertEquals(srcDef.getOrder(), destDef.getOrder());
+                        assertEquals(srcDef.getCount(), destDef.getCount());
+                        assertEquals(srcDef.getName(), destDef.getName());
+                        assertEquals(srcDef.getPropertyType(), destDef.getPropertyType());
+                        assertEquals(srcDef.getUom(), destDef.getUom());
+                        assertEquals(srcDef.getUid(), destDef.getUid());
+                        assertEquals(srcDef.getDoubleValues(), destDef.getDoubleValues());
+                        assertEquals(srcDef.getStringValues(), destDef.getStringValues());
+                    }
+                }
+            }
+        }
 
     }
 

--- a/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
+++ b/src/test/java/com/hashmapinc/tempus/WitsmlObjects/Util/LogConverterTest.java
@@ -1,0 +1,115 @@
+package com.hashmapinc.tempus.WitsmlObjects.Util;
+
+import org.junit.Test;
+
+public class LogConverterTest {
+    //=========================================================================
+    // conversions to 1.3.1.1
+    //=========================================================================
+    @Test
+    public void shouldConvert1411to1311() throws Exception {
+        String srcXML = TestUtilities.getResourceAsString("log_converter/log1411.xml");
+        com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog src = ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLogs)WitsmlMarshal.deserialize(srcXML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog.class)).getLog().get(0);
+
+        // get converted log
+        com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog dest = LogConverter.convertTo1311(src);
+
+        // check equality for non complex, non repeating fields
+
+        // check complex fields
+
+        // check repeating fields
+
+    }
+
+    @Test
+    public void shouldConvert20to1311() throws Exception {
+        String srcXML = TestUtilities.getResourceAsString("log_converter/log20.xml");
+        com.hashmapinc.tempus.WitsmlObjects.v20.Log src = WitsmlMarshal.deserialize(srcXML, com.hashmapinc.tempus.WitsmlObjects.v20.Log.class);
+
+        // get converted log
+        com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog dest = LogConverter.convertTo1311(src);
+
+        // check equality for non complex, non repeating fields
+
+        // check complex fields
+
+        // check repeating fields
+
+    }
+    //=========================================================================
+
+
+    //=========================================================================
+    // conversions to 1.4.1.1
+    //=========================================================================
+    @Test
+    public void shouldConvert1311to1411()  throws Exception {
+        String srcXML = TestUtilities.getResourceAsString("log_converter/log1311.xml");
+        com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog src = ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLogs)WitsmlMarshal.deserialize(srcXML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog.class)).getLog().get(0);
+
+        // get converted log
+        com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog dest = LogConverter.convertTo1411(src);
+
+        // check equality for non complex, non repeating fields
+
+        // check complex fields
+
+        // check repeating fields
+
+    }
+
+    @Test
+    public void shouldConvert20to1411() throws Exception {
+        String srcXML = TestUtilities.getResourceAsString("log_converter/log20.xml");
+        com.hashmapinc.tempus.WitsmlObjects.v20.Log src = WitsmlMarshal.deserialize(srcXML, com.hashmapinc.tempus.WitsmlObjects.v20.Log.class);
+
+        // get converted log
+        com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog dest = LogConverter.convertTo1411(src);
+
+        // check equality for non complex, non repeating fields
+
+        // check complex fields
+
+        // check repeating fields
+
+    }
+    //=========================================================================
+
+
+    //=========================================================================
+    // conversions to 2.0
+    //=========================================================================
+    @Test
+    public void shouldConvert1311to20() throws Exception {
+        String srcXML = TestUtilities.getResourceAsString("log_converter/log1311.xml");
+        com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog src = ((com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLogs)WitsmlMarshal.deserialize(srcXML, com.hashmapinc.tempus.WitsmlObjects.v1311.ObjLog.class)).getLog().get(0);
+
+        // get converted log
+        com.hashmapinc.tempus.WitsmlObjects.v20.Log dest = LogConverter.convertTo20(src);
+
+        // check equality for non complex, non repeating fields
+
+        // check complex fields
+
+        // check repeating fields
+
+    }
+
+    @Test
+    public void shouldConvert1411to20() throws Exception {
+        String srcXML = TestUtilities.getResourceAsString("log_converter/log1411.xml");
+        com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog src = ((com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLogs)WitsmlMarshal.deserialize(srcXML, com.hashmapinc.tempus.WitsmlObjects.v1411.ObjLog.class)).getLog().get(0);
+
+        // get converted log
+        com.hashmapinc.tempus.WitsmlObjects.v20.Log dest = LogConverter.convertTo20(src);
+
+        // check equality for non complex, non repeating fields
+
+        // check complex fields
+
+        // check repeating fields
+
+    }
+    //=========================================================================
+}

--- a/src/test/resources/log_converter/log1311.xml
+++ b/src/test/resources/log_converter/log1311.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="../stylesheets/log.xsl" type="text/xsl" media="screen"?>
+<!--   		Example of Log data 		-->
+<logs 
+	xmlns="http://www.witsml.org/schemas/131" 	
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://www.witsml.org/schemas/131  ../obj_log.xsd" 
+	version="1.3.1.1">
+
+	<documentInfo>
+		<DocumentName>Log</DocumentName>
+		<FileCreationInformation>
+			<FileCreationDate>2001-10-31T08:15:00.000</FileCreationDate>
+			<SoftwareName>WITSML 1.3.0.0 Server</SoftwareName>
+			<FileCreator>John Smith</FileCreator>
+		</FileCreationInformation>
+	</documentInfo>
+	<log uidWell="W-12" uidWellbore="B-01" uid="f34a">
+		<nameWell>6507/7-A-42</nameWell>
+		<nameWellbore>A-42</nameWellbore>
+		<name>L001</name>
+		<serviceCompany>Baker Hughes INTEQ</serviceCompany>
+		<runNumber>12.3</runNumber>
+		<creationDate>2001-06-18T13:20:00.000</creationDate>
+		<description>Drilling Data Log</description>
+		<indexType>measured depth</indexType>
+		<startIndex uom="m">499</startIndex>
+		<endIndex uom="m">509.01</endIndex>
+		<stepIncrement uom="m">0</stepIncrement>
+		<direction>increasing</direction>
+		<indexCurve columnIndex="1">Mdepth</indexCurve>
+		<nullValue>-999.25</nullValue>
+		<logParam index="1" name="MRES" uom="ohm.m" description="Mud Resistivity">1.25</logParam>
+		<logParam index="2" name="BDIA" uom="in" description="Bit Diameter">12.25</logParam>
+		<logCurveInfo uid="lci-1">
+			<mnemonic>Mdepth</mnemonic>
+			<classWitsml>measured depth of hole</classWitsml>
+			<unit>m</unit>
+			<mnemAlias>md</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>1</columnIndex>
+			<curveDescription>Measured depth</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-2">
+			<mnemonic>Vdepth</mnemonic>
+			<classWitsml>TVD of hole</classWitsml>
+			<unit>m</unit>
+			<mnemAlias>tvd</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>2</columnIndex>
+			<curveDescription>Vertical depth</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-3">
+			<mnemonic>Bit Dist</mnemonic>
+			<classWitsml>measured depth of DST bottom</classWitsml>
+			<unit>m</unit>
+			<mnemAlias>distBit</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>3</columnIndex>
+			<curveDescription>Distance drilled by bit</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-4">
+			<mnemonic>TQ on btm</mnemonic>
+			<classWitsml>torque (average)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>tqOnBot</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>4</columnIndex>
+			<curveDescription>On bottom torque</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-5">
+			<mnemonic>TQ off btm</mnemonic>
+			<classWitsml>torque (average)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>toOffBot</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>5</columnIndex>
+			<curveDescription>Off bottom torque</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-6">
+			<mnemonic>ROP</mnemonic>
+			<classWitsml>rate of penetration (average)</classWitsml>
+			<unit>m/h</unit>
+			<mnemAlias>ropAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>6</columnIndex>
+			<curveDescription>Drill rate</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-7">
+			<mnemonic>WOP</mnemonic>
+			<classWitsml>weight on bit (average)</classWitsml>
+			<unit>klbf</unit>
+			<mnemAlias>wobAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>7</columnIndex>
+			<curveDescription>Weight on bit</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-8">
+			<mnemonic>HKLD</mnemonic>
+			<classWitsml>hookload (average)</classWitsml>
+			<unit>klbf</unit>
+			<mnemAlias>hkldAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>8</columnIndex>
+			<curveDescription>Hookload</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-9">
+			<mnemonic>Surf RPM</mnemonic>
+			<classWitsml>rotary speed (average)</classWitsml>
+			<unit>rpm</unit>
+			<mnemAlias>rpmAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>9</columnIndex>
+			<curveDescription>RPM measured at surface</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-10">
+			<mnemonic>Mtr RPM</mnemonic>
+			<classWitsml>measured motor speed</classWitsml>
+			<unit>rpm</unit>
+			<mnemAlias>mmrpm</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>10</columnIndex>
+			<curveDescription>Calculated motor RPM</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-11">
+			<mnemonic>Avg TQ</mnemonic>
+			<classWitsml>torque (average)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>tqAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>11</columnIndex>
+			<curveDescription>Average drilling torque</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-12">
+			<mnemonic>Max TQ</mnemonic>
+			<classWitsml>torque (maximum)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>torque (maximum)</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>12</columnIndex>
+			<curveDescription>Maximum drilling torque</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-13">
+			<mnemonic>Min TQ</mnemonic>
+			<classWitsml>torque (average)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>tqMn</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>13</columnIndex>
+			<curveDescription>Minimum drilling torque</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-14">
+			<mnemonic>Max - Min TQ</mnemonic>
+			<classWitsml>torque (maximum)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>tqMx-Mn</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>14</columnIndex>
+			<curveDescription>Maximum - minimum drilling torque</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-15">
+			<mnemonic>Mud Flow in Avg</mnemonic>
+			<classWitsml>flow rate in (average)</classWitsml>
+			<unit>galUS/min</unit>
+			<mnemAlias>flowInAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>15</columnIndex>
+			<curveDescription>Average mud flow in</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-16">
+			<mnemonic>Pump p avg</mnemonic>
+			<classWitsml>pressure at pump (average)</classWitsml>
+			<unit>galUS/min</unit>
+			<mnemAlias>presPumpAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>16</columnIndex>
+			<curveDescription>Average pump pressure</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-17">
+			<mnemonic>Mud D avg</mnemonic>
+			<classWitsml>mud density in (average)</classWitsml>
+			<unit>g/cm3</unit>
+			<mnemAlias>wtMudInAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>17</columnIndex>
+			<curveDescription>Average mud density</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-18">
+			<mnemonic>Mud Temp avg</mnemonic>
+			<classWitsml>mud temperature in (average)</classWitsml>
+			<unit>degC</unit>
+			<mnemAlias>tempMudInAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>18</columnIndex>
+			<curveDescription>Average mud temperature</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-19">
+			<mnemonic>Bit RPM</mnemonic>
+			<classWitsml>rotary speed (average)</classWitsml>
+			<unit>rpm</unit>
+			<mnemAlias>rpmBitAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>19</columnIndex>
+			<curveDescription>Bit RPM</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-20">
+			<mnemonic>DXC</mnemonic>
+			<classWitsml>drilling exponent (corrected)</classWitsml>
+			<mnemAlias>dxc</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>20</columnIndex>
+			<curveDescription>d exponent</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-21">
+			<mnemonic>ECD</mnemonic>
+			<classWitsml>ecdTd ???????????</classWitsml>
+			<unit>g/cm3</unit>
+			<mnemAlias>ecdTd</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<columnIndex>21</columnIndex>
+			<curveDescription>equivalent circulating density</curveDescription>
+			<sensorOffset uom="ft">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logData>
+			<data>499,498.99,1.25,0,1.45,3.67,11.02,187.66,0.29,116.24,0.01,0.05,0.01,0,886.03,1089.99,1.11,14.67,0.29,1.12,1.11</data>
+			<data>500.01,500,1.9,0.01,1.42,9.94,11.32,185.7,0.29,116.24,0.01,0.01,0.01,0,795.19,973.48,1.11,14.67,0.29,0.95,1.11</data>
+			<data>501.03,501.02,2.92,0.02,1.41,20.46,11.62,184.23,0.29,120,0.01,0.01,0.01,0,796.68,956.25,1.11,14.67,0.29,0.83,1.11</data>
+			<data>502.01,502,3.9,0.06,1.44,21.73,10.37,185.49,0.29,120,0.01,0.01,0.01,0,802.96,1005.68,1.1,14.66,0.3,0.8,1.11</data>
+			<data>503.01,503,4.9,0.11,1.48,17.65,10.31,185.55,0.29,118.09,0.01,0.01,0.01,0,801.19,1007.77,1.11,14.66,0.3,0.83,1.11</data>
+			<data>504.05,504.04,5.94,0.18,1.55,15.58,10.4,185.43,0.29,120,0.01,0.01,0.01,0,800.83,1015.89,1.1,14.67,0.29,0.86,1.11</data>
+			<data>505.03,505.00,612.03,1.83,3.32,37.11,18.5,243.38,91.93,0,8.07,8.35,7.68,0.19,900.07,3205,1.26,29.67,93.74,0.75,1.31</data>
+			<data>506.04,505.95,613.04,1.9,3.4,9.85,27.79,233.9,79,0,8.31,10.24,6.83,1.02,907.9,3210,1.26,29.8,95,1.09,1.31</data>
+			<data>507.04,506.91,614.04,1.97,3.46,32.44,23.13,238.59,77.35,0,7.93,8.96,7.76,0.14,911.55,3223.33,1.26,29.88,89.19,0.78,1.31</data>
+			<data>508.01,507.84,615.01,2,3.49,29.03,19.38,242.36,90.59,0,8.32,8.78,7.76,0.32,899.74,3222.17,1.26,29.95,91.66,0.8,1.31</data>
+			<data>509.01,508.75,616.01,2.08,3.54,13.09,15.89,245.92,93.38,0,7.62,11.87,6.43,0.86,900.93,3215.78,1.26,30.06,98.51,0.92,1.31</data>
+		</logData>
+		<commonData>
+			<dTimCreation>2003-11-24T08:15:00.000</dTimCreation>
+			<dTimLastChange>2003-11-24T08:15:00.000</dTimLastChange>
+			<itemState>plan</itemState>
+			<comments>These are the comments associated with the log object.</comments>
+		</commonData>
+	</log>
+</logs>

--- a/src/test/resources/log_converter/log1411.xml
+++ b/src/test/resources/log_converter/log1411.xml
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="./stylesheets/generic.xsl" type="text/xsl" media="screen"?>
+<!--   		Example of Log data 		-->
+<logs 
+	xmlns="http://www.witsml.org/schemas/1series" 	
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://www.witsml.org/schemas/1series  ../xsd_schemas/obj_log.xsd" 
+	version="1.4.1.1">
+<!-- 
+These examples are only intended to demonstrate the type of data that can be exchanged.
+They totally artificial and are not intended to demonstrate best practices. 
+-->
+	<documentInfo>
+		<documentName>Log</documentName>
+		<fileCreationInformation>
+			<fileCreationDate>2001-10-31T08:15:00.000Z</fileCreationDate> 
+			<fileCreator>John Smith</fileCreator>
+		</fileCreationInformation>
+	</documentInfo>
+	<log uidWell="W-12" uidWellbore="B-01" uid="f34a">
+		<nameWell>6507/7-A-42</nameWell>
+		<nameWellbore>A-42</nameWellbore>
+		<name>L001</name>
+		<serviceCompany>Baker Hughes INTEQ</serviceCompany>
+		<runNumber>12</runNumber>
+		<creationDate>2001-06-18T13:20:00.000Z</creationDate>
+		<description>Drilling Data Log</description>
+		<indexType>measured depth</indexType>
+		<startIndex uom="m">499</startIndex>
+		<endIndex uom="m">509.01</endIndex>
+		<stepIncrement uom="m">0</stepIncrement>
+		<direction>increasing</direction>
+		<indexCurve>Mdepth</indexCurve>
+		<nullValue>-999.25</nullValue>
+		<logParam index="1" name="MRES" uom="ohm.m" description="Mud Resistivity" uid="lp-1">1.25</logParam>
+		<logParam index="2" name="BDIA" uom="in" description="Bit Diameter" uid="lp-2">12.25</logParam>
+		<logCurveInfo uid="lci-1">
+			<mnemonic>Mdepth</mnemonic>
+			<classWitsml>measured depth of hole</classWitsml>
+			<unit>m</unit>
+			<mnemAlias>md</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Measured depth</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-2">
+			<mnemonic>Vdepth</mnemonic>
+			<classWitsml>TVD of hole</classWitsml>
+			<unit>m</unit>
+			<mnemAlias>tvd</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Vertical depth</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-3">
+			<mnemonic>Bit Dist</mnemonic>
+			<classWitsml>measured depth of DST bottom</classWitsml>
+			<unit>m</unit>
+			<mnemAlias>distBit</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Distance drilled by bit</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-4">
+			<mnemonic>TQ on btm</mnemonic>
+			<classWitsml>torque (average)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>tqOnBot</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>On bottom torque</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-5">
+			<mnemonic>TQ off btm</mnemonic>
+			<classWitsml>torque (average)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>toOffBot</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Off bottom torque</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-6">
+			<mnemonic>ROP</mnemonic>
+			<classWitsml>rate of penetration (average)</classWitsml>
+			<unit>m/h</unit>
+			<mnemAlias>ropAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Drill rate</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-7">
+			<mnemonic>WOP</mnemonic>
+			<classWitsml>weight on bit (average)</classWitsml>
+			<unit>klbf</unit>
+			<mnemAlias>wobAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Weight on bit</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-8">
+			<mnemonic>HKLD</mnemonic>
+			<classWitsml>hookload (average)</classWitsml>
+			<unit>klbf</unit>
+			<mnemAlias>hkldAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Hookload</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-9">
+			<mnemonic>Surf RPM</mnemonic>
+			<classWitsml>rotary speed (average)</classWitsml>
+			<unit>rpm</unit>
+			<mnemAlias>rpmAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>RPM measured at surface</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-10">
+			<mnemonic>Mtr RPM</mnemonic>
+			<classWitsml>measured motor speed</classWitsml>
+			<unit>rpm</unit>
+			<mnemAlias>mmrpm</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Calculated motor RPM</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-11">
+			<mnemonic>Avg TQ</mnemonic>
+			<classWitsml>torque (average)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>tqAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Average drilling torque</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-12">
+			<mnemonic>Max TQ</mnemonic>
+			<classWitsml>torque (maximum)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>torque (maximum)</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Maximum drilling torque</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-13">
+			<mnemonic>Min TQ</mnemonic>
+			<classWitsml>torque (average)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>tqMn</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Minimum drilling torque</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-14">
+			<mnemonic>Max - Min TQ</mnemonic>
+			<classWitsml>torque (maximum)</classWitsml>
+			<unit>kft.lbf</unit>
+			<mnemAlias>tqMx-Mn</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Maximum - minimum drilling torque</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-15">
+			<mnemonic>Max - Min TQ</mnemonic>
+			<classWitsml>flow rate in (average)</classWitsml>
+			<unit>galUS/min</unit>
+			<mnemAlias>flowInAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Average mud flow in</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-16">
+			<mnemonic>Pump p avg</mnemonic>
+			<classWitsml>pressure at pump (average)</classWitsml>
+			<unit>galUS/min</unit>
+			<mnemAlias>presPumpAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Average pump pressure</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-17">
+			<mnemonic>Mud D avg</mnemonic>
+			<classWitsml>mud density in (average)</classWitsml>
+			<unit>g/cm3</unit>
+			<mnemAlias>wtMudInAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Average mud density</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-18">
+			<mnemonic>Mud Temp avg</mnemonic>
+			<classWitsml>mud temperature in (average)</classWitsml>
+			<unit>degC</unit>
+			<mnemAlias>tempMudInAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Average mud temperature</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-19">
+			<mnemonic>Bit RPM</mnemonic>
+			<classWitsml>rotary speed (average)</classWitsml>
+			<unit>rpm</unit>
+			<mnemAlias>rpmBitAv</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>Bit RPM</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-20">
+			<mnemonic>DXC</mnemonic>
+			<classWitsml>drilling exponent (corrected)</classWitsml>
+			<mnemAlias>dxc</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>d exponent</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logCurveInfo uid="lci-21">
+			<mnemonic>ECD</mnemonic>
+			<classWitsml>ecdTd ???????????</classWitsml>
+			<unit>g/cm3</unit>
+			<mnemAlias>ecdTd</mnemAlias>
+			<nullValue>-999.25</nullValue>
+			<minIndex uom="m">499</minIndex>
+			<maxIndex uom="m">509.01</maxIndex>
+			<curveDescription>equivalent circulating density</curveDescription>
+			<sensorOffset uom="m">0</sensorOffset>
+			<traceState>raw</traceState>
+			<typeLogData>double</typeLogData>
+		</logCurveInfo>
+		<logData>
+			<mnemonicList>Mdepth,Vdepth,Bit Dist,TQ on btm,TQ off btm,ROP,WOP,HKLD,Surf RPM,Mtr RPM,Avg TQ,Max TQ,Min TQ,Max - Min TQ,Max - Min TQ,Pump p avg,Mud D avg,Mud Temp avg,Bit RPM,DXC,ECD</mnemonicList>
+			<unitList>m,m,m,kft.lbf,kft.lbf,m/h,klbf,klbf,rpm,rpm,kft.lbf,kft.lbf,kft.lbf,kft.lbf,galUS,galUS,g/cm3,degC,rpm,,g/cm3</unitList>
+			<data>499,498.99,1.25,0,1.45,3.67,11.02,187.66,0.29,116.24,0.01,0.05,0.01,0,886.03,1089.99,1.11,14.67,0.29,1.12,1.11</data>
+			<data>500.01,500,1.9,0.01,1.42,9.94,11.32,185.7,0.29,116.24,0.01,0.01,0.01,0,795.19,973.48,1.11,14.67,0.29,0.95,1.11</data>
+			<data>501.03,501.02,2.92,0.02,1.41,20.46,11.62,184.23,0.29,120,0.01,0.01,0.01,0,796.68,956.25,1.11,14.67,0.29,0.83,1.11</data>
+			<data>502.01,502,3.9,0.06,1.44,21.73,10.37,185.49,0.29,120,0.01,0.01,0.01,0,802.96,1005.68,1.1,14.66,0.3,0.8,1.11</data>
+			<data>503.01,503,4.9,0.11,1.48,17.65,10.31,185.55,0.29,118.09,0.01,0.01,0.01,0,801.19,1007.77,1.11,14.66,0.3,0.83,1.11</data>
+			<data>504.05,504.04,5.94,0.18,1.55,15.58,10.4,185.43,0.29,120,0.01,0.01,0.01,0,800.83,1015.89,1.1,14.67,0.29,0.86,1.11</data>
+			<data>505.03,505.00,612.03,1.83,3.32,37.11,18.5,243.38,91.93,0,8.07,8.35,7.68,0.19,900.07,3205,1.26,29.67,93.74,0.75,1.31</data>
+			<data>506.04,505.95,613.04,1.9,3.4,9.85,27.79,233.9,79,0,8.31,10.24,6.83,1.02,907.9,3210,1.26,29.8,95,1.09,1.31</data>
+			<data>507.04,506.91,614.04,1.97,3.46,32.44,23.13,238.59,77.35,0,7.93,8.96,7.76,0.14,911.55,3223.33,1.26,29.88,89.19,0.78,1.31</data>
+			<data>508.01,507.84,615.01,2,3.49,29.03,19.38,242.36,90.59,0,8.32,8.78,7.76,0.32,899.74,3222.17,1.26,29.95,91.66,0.8,1.31</data>
+			<data>509.01,508.75,616.01,2.08,3.54,13.09,15.89,245.92,93.38,0,7.62,11.87,6.43,0.86,900.93,3215.78,1.26,30.06,98.51,0.92,1.31</data>
+		</logData>
+		<commonData>
+			<dTimCreation>2003-11-24T08:15:00.000Z</dTimCreation>
+			<dTimLastChange>2003-11-24T08:17:00.000Z</dTimLastChange>
+			<itemState>plan</itemState>
+			<comments>These are the comments associated with the log object.</comments>
+		</commonData>
+	</log>
+</logs>

--- a/src/test/resources/log_converter/log20.xml
+++ b/src/test/resources/log_converter/log20.xml
@@ -1,0 +1,842 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Log xmlns="http://www.energistics.org/energyml/data/witsmlv2"
+     xmlns:eml="http://www.energistics.org/energyml/data/commonv2"
+     xmlns:gco="http://www.isotc211.org/2005/gco"
+     xmlns:gmd="http://www.isotc211.org/2005/gmd"
+     xmlns:gsr="http://www.isotc211.org/2005/gsr"
+     xmlns:gts="http://www.isotc211.org/2005/gts"
+     xmlns:gml="http://www.opengis.net/gml/3.2"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.energistics.org/energyml/data/witsmlv2 ../xsd_schemas/Log.xsd"
+     schemaVersion="2.0"
+     uuid="00000000-0000-0000-0000-000000000000">
+   <eml:Aliases authority="1.4.1.1">
+      <eml:Identifier>W-12B-01f34a</eml:Identifier>
+      <eml:Description>Identifier is created from the uid of the input scheme</eml:Description>
+   </eml:Aliases>
+   <eml:Citation>
+      <eml:Title>L001</eml:Title>
+      <eml:Originator>1411_input</eml:Originator>
+      <eml:Creation>2018-01-23T08:18:18.731-06:00</eml:Creation>
+      <eml:Format>Mapforce</eml:Format>
+      <eml:LastUpdate>2003-11-24T08:17:00Z</eml:LastUpdate>
+   </eml:Citation>
+   <TimeDepth>measured depth</TimeDepth>
+   <RunNumber>12</RunNumber>
+   <StartIndex xsi:type="DepthIndexValue">
+      <Depth>499</Depth>
+   </StartIndex>
+   <EndIndex xsi:type="DepthIndexValue">
+      <Depth>509.01</Depth>
+   </EndIndex>
+   <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+   <LoggingMethod>mixed</LoggingMethod>
+   <Wellbore>
+      <eml:ContentType>wellbore</eml:ContentType>
+      <eml:Title>A-42</eml:Title>
+      <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+   </Wellbore>
+   <ChannelSet schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+      <eml:Citation>
+         <eml:Title>L001</eml:Title>
+         <eml:Originator>1411_input</eml:Originator>
+         <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+         <eml:Format>Mapforce</eml:Format>
+      </eml:Citation>
+      <Index>
+         <IndexType>measured depth</IndexType>
+         <Uom>m</Uom>
+         <Direction>increasing</Direction>
+         <Mnemonic>measured depth</Mnemonic>
+      </Index>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-1">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Mdepth</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Mdepth</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-2">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Vdepth</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Vdepth</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-3">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Bit Dist</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Bit Dist</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-4">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>TQ on btm</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>TQ on btm</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-5">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>TQ off btm</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>TQ off btm</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-6">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>ROP</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>ROP</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-7">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>WOP</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>WOP</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-8">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>HKLD</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>HKLD</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-9">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Surf RPM</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Surf RPM</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-10">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Mtr RPM</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Mtr RPM</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-11">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Avg TQ</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Avg TQ</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-12">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Max TQ</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Max TQ</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-13">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Min TQ</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Min TQ</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-14">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Max - Min TQ</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Max - Min TQ</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-15">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Max - Min TQ</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Max - Min TQ</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-16">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Pump p avg</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Pump p avg</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-17">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Mud D avg</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Mud D avg</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-18">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Mud Temp avg</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Mud Temp avg</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-19">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>Bit RPM</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>Bit RPM</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-20">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>DXC</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>DXC</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Channel schemaVersion="2.0.0.0" uuid="00000000-0000-0000-0000-000000000000">
+         <eml:Aliases authority="lci-21">
+            <eml:Identifier>Identifier for this channel</eml:Identifier>
+         </eml:Aliases>
+         <eml:Citation>
+            <eml:Title>ECD</eml:Title>
+            <eml:Originator>1411_input</eml:Originator>
+            <eml:Creation>2003-11-24T08:15:00Z</eml:Creation>
+            <eml:Format>Mapforce</eml:Format>
+         </eml:Citation>
+         <Mnemonic>ECD</Mnemonic>
+         <DataType>double</DataType>
+         <Uom>m</Uom>
+         <GrowingStatus>active</GrowingStatus>
+         <TimeDepth>time</TimeDepth>
+         <ChannelClass>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>title</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelClass>
+         <StartIndex xsi:type="DepthIndexValue">
+            <Depth>499</Depth>
+         </StartIndex>
+         <EndIndex xsi:type="DepthIndexValue">
+            <Depth>509.01</Depth>
+         </EndIndex>
+         <LoggingCompanyName>Baker Hughes INTEQ</LoggingCompanyName>
+         <Derivation>raw</Derivation>
+         <LoggingMethod>mixed</LoggingMethod>
+         <NominalHoleSize uom="m">-999</NominalHoleSize>
+         <Index>
+            <IndexType>measured depth</IndexType>
+            <Uom>m</Uom>
+            <Direction>decreasing</Direction>
+            <Mnemonic>DEPTH</Mnemonic>
+         </Index>
+      </Channel>
+      <Data>
+         <Data/>
+      </Data>
+      <DataContext xsi:type="ChannelValueContext">
+         <ChannelReference>
+            <eml:ContentType>log</eml:ContentType>
+            <eml:Title>DEPTH</eml:Title>
+            <eml:Uuid>00000000-0000-0000-0000-000000000000</eml:Uuid>
+         </ChannelReference>
+         <DataValue>-999</DataValue>
+      </DataContext>
+   </ChannelSet>
+</Log>


### PR DESCRIPTION
Part 1 of 2 for df-232 Log Converter support.

This PR includes:
- general skeleton for full 1.4.1.1/1.3.1.1/2.0 conversion of singular Log objects
- test suite for 1311/1411 conversions
- LogConverter support for 1311/1411 conversions
- subclass conversion methods throughout