### PR TITLE
Trajectory 20 serialization from AWOs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hashmapinc.tempus</groupId>
     <artifactId>WitsmlObjects</artifactId>
-    <version>1.1.17</version>
+    <version>1.1.18</version>
     <packaging>jar</packaging>
 
     <name>WITSML Objects Helper Library</name>

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/ObjTrajectory.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/ObjTrajectory.java
@@ -770,6 +770,8 @@ public class ObjTrajectory extends AbstractWitsmlObject {
                 return WitsmlMarshal.serializeToJSON(TrajectoryConverter.convertTo1411(this));
             } else if ("1.3.1.1".equals(version)) {
                 return WitsmlMarshal.serializeToJSON(this);
+            } else if ("2.0".equals(version)) {
+                return WitsmlMarshal.serializeToJSON(TrajectoryConverter.convertTo20(this));
             } else {
                 return null; // unsupported version
             }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/ObjTrajectory.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1311/ObjTrajectory.java
@@ -748,6 +748,8 @@ public class ObjTrajectory extends AbstractWitsmlObject {
                 ObjTrajectorys trajectorys = new ObjTrajectorys();
                 trajectorys.addTrajectory(this);
                 return WitsmlMarshal.serialize(trajectorys);
+            } else if ("2.0".equals(version)) {
+                return WitsmlMarshal.serialize(TrajectoryConverter.convertTo20(this));
             } else {
                 return null;
             }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/ObjTrajectory.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v1411/ObjTrajectory.java
@@ -811,7 +811,9 @@ public class ObjTrajectory extends AbstractWitsmlObject {
                 ObjTrajectorys trajectorys = new ObjTrajectorys();
                 trajectorys.addTrajectory(this);
                 return WitsmlMarshal.serialize(trajectorys);
-            } else {
+            } else if ("2.0".equals(version)) {
+                return WitsmlMarshal.serialize(TrajectoryConverter.convertTo20(this));
+        } else {
                 return null;
             }
         } catch (Exception e) {
@@ -833,6 +835,8 @@ public class ObjTrajectory extends AbstractWitsmlObject {
                 return WitsmlMarshal.serializeToJSON(TrajectoryConverter.convertTo1311(this));
             } else if ("1.4.1.1".equals(version)) {
                 return WitsmlMarshal.serializeToJSON(this);
+            } else if ("2.0".equals(version)) {
+                return WitsmlMarshal.serializeToJSON(TrajectoryConverter.convertTo20(this));
             } else {
                 return null; // unsupported version
             }

--- a/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v20/Trajectory.java
+++ b/src/main/java/com/hashmapinc/tempus/WitsmlObjects/v20/Trajectory.java
@@ -5,11 +5,7 @@ package com.hashmapinc.tempus.WitsmlObjects.v20;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.*;
 
 
 /**
@@ -50,6 +46,7 @@ import javax.xml.bind.annotation.XmlType;
  * 
  * 
  */
+@XmlRootElement(name="Trajectory")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Trajectory", namespace = "http://www.energistics.org/energyml/data/witsmlv2", propOrder = {
     "growingStatus",

--- a/src/test/java/com/hashmapinc/tempus/WitsmlObjects/AbstractWitsmlObjectTest.java
+++ b/src/test/java/com/hashmapinc/tempus/WitsmlObjects/AbstractWitsmlObjectTest.java
@@ -54,11 +54,19 @@ public class AbstractWitsmlObjectTest {
         String serializedXML1311 = obj1311.getXMLString("1.3.1.1");
         assertNotNull(serializedXML1311);
         assertFalse(serializedXML1311.contains("ns0:wells"));
+        assertNotEquals(0, serializedXML1311.length());
 
         // check cross-version serialization
         String translatedXML1411 = obj1311.getXMLString("1.4.1.1");
         assertNotNull(translatedXML1411);
         assertFalse(translatedXML1411.contains("ns0:wells"));
+        assertNotEquals(0, translatedXML1411.length());
+
+        // check 20 serialization
+        String serializedXML20from1311 = obj1311.getXMLString("2.0");
+        assertNotNull(serializedXML20from1311);
+        assertFalse(serializedXML20from1311.contains("ns0:wells"));
+        assertNotEquals(0, serializedXML20from1311.length());
         //=====================================================================
 
         //=====================================================================
@@ -72,11 +80,19 @@ public class AbstractWitsmlObjectTest {
         String serializedXML1411 = obj1411.getXMLString("1.4.1.1");
         assertNotNull(serializedXML1411);
         assertFalse(serializedXML1411.contains("ns0:wells"));
+        assertNotEquals(0, serializedXML1411.length());
 
         // check cross-version serialization
         String translatedXML1311 = obj1411.getXMLString("1.3.1.1");
         assertNotNull(translatedXML1311);
         assertFalse(translatedXML1311.contains("ns0:wells"));
+        assertNotEquals(0, translatedXML1311.length());
+
+        // check 20 serialization
+        String serializedXML20from1411 = obj1411.getXMLString("2.0");
+        assertNotNull(serializedXML20from1411);
+        assertFalse(serializedXML20from1411.contains("ns0:wells"));
+        assertNotEquals(0, serializedXML20from1411.length());
         //=====================================================================
     }
 
@@ -98,6 +114,12 @@ public class AbstractWitsmlObjectTest {
         String translatedJSON1411 = obj1311.getJSONString("1.4.1.1");
         assertNotNull(translatedJSON1411);
         assertNotEquals(0, translatedJSON1411.length());
+
+        // check 20 serialization
+        String serializedJSON20from1311 = obj1311.getJSONString("2.0");
+        assertNotNull(serializedJSON20from1311);
+        assertFalse(serializedJSON20from1311.contains("ns0:wells"));
+        assertNotEquals(0, serializedJSON20from1311.length());
         //=====================================================================
 
         //=====================================================================
@@ -115,6 +137,11 @@ public class AbstractWitsmlObjectTest {
         // check cross-version serialization
         String translatedJSON1311 = obj1411.getJSONString("1.3.1.1");
         assertNotNull(translatedJSON1311);
+        assertNotEquals(0, translatedJSON1311.length());
+
+        // check 20 serialization
+        String serializedJSON20from1411 = obj1411.getJSONString("2.0");
+        assertNotNull(serializedJSON20from1411);
         assertNotEquals(0, translatedJSON1311.length());
         //=====================================================================
     }


### PR DESCRIPTION
This PR includes:
- tests to ensure AWOs can serialize to 20 xml/json for trajectories
- support for trajectory AWO concrete classes to serialize to 2.0 xml or json
- upgrade to v1.1.18